### PR TITLE
Ajout de refreshToken dans la config & fixs JWT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export class Skolengo {
     this.config = {
       httpClient: config?.httpClient ?? axios.create({ baseURL: BASE_URL }),
       onTokenRefresh: config?.onTokenRefresh ?? (() => {}),
+      refreshToken: config?.refreshToken,
       handlePronoteError: config?.handlePronoteError ?? false
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,7 +1057,9 @@ export class Skolengo {
    */
   public getTokenClaims (): IdTokenClaims {
     if (this.tokenSet.id_token === undefined) throw new TypeError('id_token not present in TokenSet')
-    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') ?? ''))
+    const dataPart = this.tokenSet.id_token.split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/')
+    if (dataPart === undefined || dataPart.trim().length === 0) throw new TypeError('Invalid id_token')
+    return JSON.parse(atob(dataPart))
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,7 +1057,7 @@ export class Skolengo {
    */
   public getTokenClaims (): IdTokenClaims {
     if (this.tokenSet.id_token === undefined) throw new TypeError('id_token not present in TokenSet')
-    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') || ''))
+    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') ?? ''))
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,7 +1057,7 @@ export class Skolengo {
    */
   public getTokenClaims (): IdTokenClaims {
     if (this.tokenSet.id_token === undefined) throw new TypeError('id_token not present in TokenSet')
-    return JSON.parse(atob((this.tokenSet.id_token).split('.')[1].replace(/-/g, "+").replace(/_/g, "/")))
+    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') || ""))
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,7 +1057,7 @@ export class Skolengo {
    */
   public getTokenClaims (): IdTokenClaims {
     if (this.tokenSet.id_token === undefined) throw new TypeError('id_token not present in TokenSet')
-    return JSON.parse(atob((this.tokenSet.id_token).split('.')[1]))
+    return JSON.parse(atob((this.tokenSet.id_token).split('.')[1].replace(/-/g, "+").replace(/_/g, "/")))
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1057,7 +1057,7 @@ export class Skolengo {
    */
   public getTokenClaims (): IdTokenClaims {
     if (this.tokenSet.id_token === undefined) throw new TypeError('id_token not present in TokenSet')
-    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') || ""))
+    return JSON.parse(atob((this.tokenSet.id_token).split('.')?.at(1)?.replace(/-/g, '+').replace(/_/g, '/') || ''))
   }
 
   /**


### PR DESCRIPTION
# Description de la demande de fusion

Il y a eu un oubli dans le constructeur. Selon la documentation, on peut passer en paramètre une fonction `refreshToken`, mais elle n'est jamais ajouté dans la config `this.config`.
Un petit fix également pour le JWT qui dans certains cas ne marche pas. En se basant sur [jwt-decode](https://github.com/auth0/jwt-decode/blob/main/lib/index.ts#L38), l'ajout de deux replace semble fonctionner.

## Type de changement

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] Mon code ne met pas en danger les données personnelles des utilisateurs
- [x] Les noms des commits suivent la convention [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/) (normalement)
- [x] J'ai vérifié l'entièreté du code avant de le soumettre 
- [ ] J'ai mis à jour la documentation en lien avec mes commits (aucune modification)
- [x] Mon code ne génère pas d'erreurs
- [ ] J'ai ajouté les tests d'intégration correspondants (dossier `tests`) (aucune modification)
- [x] Les anciens et nouveaux tests d'intégration sont validés en local (aucune modification)

### Note
Avant de fusionner cette PR, elle devra recevoir l'approbation d'au moins une des personnes suivantes :
- [@maelgangloff](https://github.com/maelgangloff)
